### PR TITLE
Link to github for new issues when artifacthub eventually scans the repo

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -25,6 +25,9 @@ maintainers:
   - name: Gavin Mogan
     email: helm@gavinmogan.com
 annotations:
+  artifacthub.io/links: |
+    - name: support
+      url: https://github.com/vouch/helm-charts/issues/new/choose
   artifacthub.io/changes: |
     - Add ingress class name
   artifacthub.io/containsSecurityUpdates: "false"


### PR DESCRIPTION
https://artifacthub.io/docs/topics/annotations/helm/ has annotations
Apparently support is a special one

Hopefully this will prevent direct emails for help in the future