### PR TITLE
Adding extraEnvVars option to add environment variables to the vouch deployment

### DIFF
--- a/charts/vouch/Chart.yaml
+++ b/charts/vouch/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 type: application
 appVersion: "0.36"
-version: 3.0.5
+version: 3.1.0
 name: vouch
 description: An SSO and OAuth login solution for nginx using the auth_request module.
 icon: https://avatars0.githubusercontent.com/u/45102943?s=200&v=4

--- a/charts/vouch/README.md.gotmpl
+++ b/charts/vouch/README.md.gotmpl
@@ -7,6 +7,9 @@
 
 ## Changelog
 
+3.1.0
+  * Add extraEnvVars option to add env variables to the vouch deployment
+
 2.0.0
   * Require Vouch secret to be set (#8 thanks @punkle)
   * Add image command and args in deployment template (#6 thanks @tidalf)

--- a/charts/vouch/templates/deployment.yaml
+++ b/charts/vouch/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
           env:
             - name: VOUCH_PORT
               value: {{ .Values.config.vouch.port | quote }}
+            {{- range .Values.extraEnvVars }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.config.vouch.port }}

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -124,3 +124,10 @@ config:
 
 # existingSecretName -- Allow overriding the config value with an existing secret, like a sealed secret
 existingSecretName: ""
+
+# An array to add extra environment variables
+# Example:
+# extraEnvVars:
+#   - name: HTTPS_PROXY
+#     value: "https://example.com"
+extraEnvVars: []


### PR DESCRIPTION
This feature add allows you to use the vouch proxy helm chart in environments that require `HTTP_PROXY` and `HTTPS_PROXY` to be set for outgoing requests, which is necessary to validate JWT tokens against the configured oauth server.

Relates to https://github.com/vouch/vouch-proxy/issues/291